### PR TITLE
Introduce getProjectsDir() and getTempDir().

### DIFF
--- a/creepy/CreepyMain.py
+++ b/creepy/CreepyMain.py
@@ -134,10 +134,8 @@ class MainWindow(QMainWindow):
         self.ui = Ui_CreepyMainWindow()
         self.ui.setupUi(self)
         # Create folders for projects and temp if they do not exist
-        if not os.path.exists(os.path.join(os.getcwd(), 'projects')):
-            os.makedirs(os.path.join(os.getcwd(), 'projects'))
-        if not os.path.exists(os.path.join(os.getcwd(), 'temp')):
-            os.makedirs(os.path.join(os.getcwd(), 'temp'))
+        GeneralUtilities.getProjectsDir()
+        GeneralUtilities.getTempDir()
         self.projectsList = []
         self.currentProject = None
         self.ui.mapWebPage = QWebPage()
@@ -850,7 +848,7 @@ class MainWindow(QMainWindow):
         Loads all the existing projects from the storage to be shown in the UI
         """
         # Show the existing Projects 
-        projectsDir = os.path.join(os.getcwd(), 'projects')
+        projectsDir = GeneralUtilities.getProjectsDir()
         projectFileNames = [os.path.join(projectsDir, f) for f in os.listdir(projectsDir) if
                             (os.path.isfile(os.path.join(projectsDir, f)) and f.endswith('.db'))]
         self.projectNames = [n.replace('.db', '').replace(str(projectsDir) + '/', '') for n in projectFileNames]

--- a/creepy/models/Project.py
+++ b/creepy/models/Project.py
@@ -39,7 +39,7 @@ class Project(object):
         """
         projectName = projectNodeObject.name().encode('utf-8') + '.db'
 
-        storedProject = shelve.open(os.path.join(os.getcwd(), 'projects', projectName))
+        storedProject = shelve.open(os.path.join(GeneralUtilities.getProjectsDir(), projectName))
         try:
             storedProject['project'] = projectNodeObject
         except Exception, err:
@@ -51,7 +51,7 @@ class Project(object):
     def deleteProject(self, projectName):
         # projectName comes as a Unicode, so we need to encode it to a string for shelve to find it
         try:
-            os.remove(os.path.join(os.getcwd(), 'projects', projectName.encode('utf-8')))
+            os.remove(os.path.join(GeneralUtilities.getProjectsDir(), projectName.encode('utf-8')))
         except Exception, err:
             logger.error('Error deleting the project')
             logger.exception(err)

--- a/creepy/models/ProjectWizardPossibleTargetsTable.py
+++ b/creepy/models/ProjectWizardPossibleTargetsTable.py
@@ -3,6 +3,7 @@
 from PyQt4.QtCore import QVariant, QAbstractTableModel, Qt
 from PyQt4.Qt import QPixmap, QIcon, QMimeData, QByteArray, QDataStream, QIODevice
 import os
+from utilities import GeneralUtilities
 class ProjectWizardPossibleTargetsTable(QAbstractTableModel):
     def __init__(self, targets, parents=None):
         super(ProjectWizardPossibleTargetsTable, self).__init__()
@@ -41,7 +42,8 @@ class ProjectWizardPossibleTargetsTable(QAbstractTableModel):
             column = index.column()
             if role == Qt.DecorationRole:
                 if column == 1:
-                    picturePath = os.path.join(os.getcwdu(), 'temp', target['targetPicture'])
+                    picturePath = os.path.join(GeneralUtilities.getTempDir(),
+                                               target['targetPicture'])
                     if picturePath and os.path.exists(picturePath):
                         pixmap = QPixmap(picturePath)
                         return QIcon(pixmap.scaled(30, 30, Qt.IgnoreAspectRatio, Qt.FastTransformation))

--- a/creepy/plugins/googleplus/googleplus.py
+++ b/creepy/plugins/googleplus/googleplus.py
@@ -65,7 +65,7 @@ class Googleplus(InputPlugin):
                               'targetFullname': person['displayName']}
                     #save the pic in the temp folder to show it later
                     filename = 'profile_pic_%s' % person['id']
-                    temp_file = os.path.join(os.getcwd(), 'temp', filename)
+                    temp_file = os.path.join(GeneralUtilities.getTempDir(), filename)
                     #Retieve and save the profile photo only if it does not exist
                     if not os.path.exists(temp_file):
                         urllib.urlretrieve(person['image']['url'], temp_file)

--- a/creepy/plugins/instagram/instagram.py
+++ b/creepy/plugins/instagram/instagram.py
@@ -73,7 +73,7 @@ class Instagram(InputPlugin):
                 target['targetFullname'] = i.full_name
                 # save the pic in the temp folder to show it later
                 filename = 'profile_pic_%s' % i.id
-                temp_file = os.path.join(os.getcwdu(), "temp", filename)
+                temp_file = os.path.join(GeneralUtilities.getTempDir(), filename)
                 if not os.path.exists(temp_file):
                     urllib.urlretrieve(i.profile_picture, temp_file)
                 possibleTargets.append(target)

--- a/creepy/plugins/twitter/twitter.py
+++ b/creepy/plugins/twitter/twitter.py
@@ -70,7 +70,7 @@ class Twitter(InputPlugin):
                     target['targetFullname'] = i.name
                     # save the pic in the temp folder to show it later
                     filename = 'profile_pic_%s' % i.id_str
-                    temp_file = os.path.join(os.getcwd(), "temp", filename)
+                    temp_file = os.path.join(GeneralUtilities.getTempDir(), filename)
                     # Retieve and save the profile phot only if it does not exist
                     if not os.path.exists(temp_file):
                         urllib.urlretrieve(i.profile_image_url, temp_file)

--- a/creepy/utilities/GeneralUtilities.py
+++ b/creepy/utilities/GeneralUtilities.py
@@ -32,6 +32,34 @@ def getLogDir():
     return logdir
 
 
+def getProjectsDir():
+    if os.path.exists("/usr/share/creepy"):
+        dir = os.path.join(expanduser("~/.creepy"), "projects")
+    else:
+        dir = os.path.join(os.getcwd(), 'projects')
+    try:
+        os.makedirs(dir)
+    except OSError as e:
+        if e.errno == errno.EEXIST and os.path.isdir(dir):
+            pass
+        else:
+            raise
+    return dir
+
+def getTempDir():
+    if os.path.exists("/usr/share/creepy"):
+        dir = os.path.join(expanduser("~/.creepy"), "temp")
+    else:
+        dir = os.path.join(os.getcwd(), 'temp')
+    try:
+        os.makedirs(dir)
+    except OSError as e:
+        if e.errno == errno.EEXIST and os.path.isdir(dir):
+            pass
+        else:
+            raise
+    return dir
+
 def getPluginDirs():
     if os.path.exists("/usr/share/creepy/plugins"):
         # if creepy is installed via debian package


### PR DESCRIPTION
This make it easier to redirect the projects and temp directories
when running creepy outside its build directory.