### PR TITLE
Store user configuration in the users home directory.

### DIFF
--- a/creepy/models/InputPlugin.py
+++ b/creepy/models/InputPlugin.py
@@ -4,6 +4,7 @@ from yapsy.IPlugin import IPlugin
 from configobj import ConfigObj
 import logging
 import os
+from os.path import expanduser
 from utilities import GeneralUtilities
 
 #set up logging
@@ -14,6 +15,89 @@ fh.setLevel(logging.DEBUG)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 fh.setFormatter(formatter)
 logger.addHandler(fh)
+
+class MultiLevelConfigObj(ConfigObj):
+    """
+Behaves like configobj.ConfigObj to the API users, but will load
+settings from several files in a priority list (think
+/usr/share/configfile, /etc/configfile, ~/.configfile), and only write
+settings different from the values in the previous configuration files
+into the last configuration file, which is expected to be writable.
+
+This is implemented by having one memory backed ConfigObj populated
+with information loaded from the files, and checking the files for
+content when saving.
+
+"""
+    def __init__(self, infiles = []):
+        super(MultiLevelConfigObj, self).__init__(infile=None)
+        self.backing = []
+        for infile in infiles:
+            config = ConfigObj(infile=infile)
+            self.backing.append(config)
+            for section in config.keys():
+                if not section in self:
+                    self[section] = {}
+                for key in config[section].keys():
+                    self[section][key] = config[section][key]
+
+    def write(self, outfile=None, section=None):
+        changed = False
+        if outfile is None:
+            writebackend = self.backing[len(self.backing)-1]
+        else:
+            writebackend = ConfigObj(infile=outfile)
+        if section is None:
+            sections = self.sections
+        else:
+            sections = section
+        for section in sections:
+            for key in self[section].keys():
+                saveval = None
+                for backend in self.backing:
+                    if section in backend and key in backend[section]:
+                        saveval = backend[section][key]
+                if self[section][key] != saveval:
+                    if section not in writebackend:
+                        writebackend[section] = {}
+                    writebackend[section][key] = self[section][key]
+                    changed = True
+        if changed:
+            logger.debug("writing ini file ")
+            return writebackend.write()
+        else:
+            logger.debug("not writing ini file ")
+        # Nothing changed from the files on disk, no need to write anything.
+
+    @staticmethod
+    def testclass():
+        """
+Self test assuming these files exist:
+
+***** foo.ini *****
+[foosection]
+foo=value
+
+[section]
+key=foovalue
+***** bar.ini *****
+[barsection]
+bar=value
+
+[section]
+key=barvalue
+
+"""
+        infiles = ['foo.ini', 'bar.ini', 'user.ini']
+        config = MultiLevelConfigObj(infiles=infiles)
+        if 'section' not in config:
+            print("error: section missing from config")
+        config['section'] = {}
+        config['section']['key'] = 'floffa'
+        config['foosection']['foo'] = 'replaced'
+        config['foosection']['foo'] = 'value'
+        config.write()
+        print(config)
 
 class InputPlugin(IPlugin):
     hasLocationBasedMode = False
@@ -44,49 +128,47 @@ class InputPlugin(IPlugin):
     def returnPersonalInformation(self, search_params):
         pass
 
-    def getPluginDir(self):
-        """
-        This needs to return '/usr/share/creepy/plugins' for debian based packages or os.getcwdu() for all other
-        :return:
-        """
-        debian_dir = '/usr/share/creepy/plugins'
-        if os.path.isdir(debian_dir) and os.access(debian_dir, os.W_OK):
-            return debian_dir
-        else:
-            return os.path.join(os.getcwdu(), 'plugins')
-
     def getConfigObj(self, config_filename=None):
         if config_filename is None:
             config_filename = self.name+".conf"
-        config_file = os.path.join(self.getPluginDir(), self.name, config_filename)
-        config = ConfigObj(infile=config_file)
+        configfiles = []
+        for dir in GeneralUtilities.getPluginDirs():
+            configfiles.append(expanduser(os.path.join(dir, self.name, config_filename)))
+        logger.debug("Loading config from: "+str(configfiles))
+        config = MultiLevelConfigObj(infiles = configfiles)
         config.create_empty = False
         return config
     
     def readConfiguration(self, category):
-        config = self.getConfigObj()
+        if not hasattr(self, 'config'):
+            self.config = self.getConfigObj()
         try:
-            options = config[category]
+            options = self.config[category]
         except Exception, err:
             options = None 
             logger.error('Could not load the '+category+' for the '+self.name+' plugin .')
             logger.exception(err)
-        return config,options
+        return self.config,options
 
     def saveConfiguration(self, new_config):
-        config = self.getConfigObj()
         try:
-            config['string_options'] = new_config['string_options']
-            config['boolean_options'] = new_config['boolean_options']
-            config.write()
+            # XXX Figure out why original code only stored these two sections,
+            # XXX and not all of them
+            for c in ['string_options', 'boolean_options']:
+                for l in self.config[c].keys():
+                    if self.config[c][l] != new_config[c][l]:
+                        self.config[c][l] = new_config[c][l]
+            GeneralUtilities.getLocalPluginDir(self.name)
+            self.config.write()
         except Exception, err:
             logger.error('Could not save the configuration for the '+self.name+' plugin.')
             logger.exception(err)
 
     def loadSearchConfigurationParameters(self):
-        config = self.getConfigObj()
+        if not hasattr(self, 'config'):
+            self.config = self.getConfigObj()
         try:
-            params = config['search_options']
+            params = self.config['search_options']
         except Exception, err:
             params= None
             logger.error('Could not load the search configuration parameters for the '+self.name+' plugin.')

--- a/creepy/utilities/GeneralUtilities.py
+++ b/creepy/utilities/GeneralUtilities.py
@@ -60,10 +60,23 @@ def getTempDir():
             raise
     return dir
 
+def getLocalPluginDir(pluginname):
+    if os.path.exists("/usr/share/creepy/plugins"):
+        localplugindir = expanduser(os.path.join("~/.creepy/plugins", pluginname))
+        try: os.makedirs(localplugindir)
+        except OSError as e:
+            if e.errno == errno.EEXIST and os.path.isdir(localplugindir): pass
+            else: raise
+        return localplugindir
+    else:
+        return [os.path.join(os.getcwd(), 'plugins')]
+
 def getPluginDirs():
     if os.path.exists("/usr/share/creepy/plugins"):
         # if creepy is installed via debian package
-        return ["/usr/share/creepy/plugins", os.path.join(os.getcwd(), 'plugins')]
+        return [os.path.join(os.getcwd(), 'plugins'),
+                "/usr/share/creepy/plugins",
+                '~/.creepy/plugins']
     else:
         return [os.path.join(os.getcwd(), 'plugins')]
 


### PR DESCRIPTION
Creepy is currently designed to run from the source directory and
save its plugin configuration in the current directory.  When
installed by the Debian Package to /usr/share the plugins do not work
because creepy does not have the required priviledges there.

This patch reads the configuration from /usr/share and then when
writing the new configuration, writes the non-default values to
~/.creepy.  Thereafter the configuration is read from both /usr/share
and ~/.creepy. This keeps the original configuration file intact and
allow default values to change when the package is upgraded without
having to edit files in the users home directories.